### PR TITLE
Mime types

### DIFF
--- a/src/plugins/lua/mime_types.lua
+++ b/src/plugins/lua/mime_types.lua
@@ -851,6 +851,9 @@ local function check_mime_type(task)
               fname:sub(1, ch_pos)))
     end
 
+    -- Decode hex encoded characters
+    fname = string.gsub(fname, '%%(%x%x)', function (hex) return string.char(tonumber(hex,16)) end )
+
     -- Replace potentially bad characters with '?'
     fname = fname:gsub('[^%s%g]', '?')
 

--- a/src/plugins/lua/mime_types.lua
+++ b/src/plugins/lua/mime_types.lua
@@ -1086,13 +1086,12 @@ local function check_mime_type(task)
         end
 
         if map then
-          local v
+          local v = map:get_key(ct)
           local detected_different = false
           if detected_ct and detected_ct ~= ct then
-            v = map:get_key(detected_ct)
+            local v_detected = map:get_key(detected_ct)
+	    if v_detected > v then v = v_detected end
             detected_different = true
-          else
-            v = map:get_key(ct)
           end
           if v then
             local n = tonumber(v)


### PR DESCRIPTION
Hackers sometimes try to hide the filename of an attachment by encoding some characters in HEX (e.g. "attached%2E%62at"). The most e-mail clients would decode this characters and the final filename would be "attached.bat". The mime_types plugin now decodes those characters before determining the file extension.

Additionally, the plugin now uses the higher weighted MIME type, if the detected type differs from the one specified in the Content-Type header, so we are always on the safe side.